### PR TITLE
Allow externally-managed BleakScanners to be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Allow externally managed `BleakScanner`s to be used via new `BluetoothMode` parameter. (#19)
 
 ## [v0.2.1](https://github.com/legrego/combustion_ble/releases/tag/v0.2.1) - 2024-01-22
 - Allow BleManager to be stopped and restarted (#14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- Allow externally managed `BleakScanner`s to be used via new `BluetoothMode` parameter. (#19)
+- Allow externally managed `BleakScanner`s to be used via new `BluetoothMode` parameter. (#20)
 
 ## [v0.2.1](https://github.com/legrego/combustion_ble/releases/tag/v0.2.1) - 2024-01-22
 - Allow BleManager to be stopped and restarted (#14)

--- a/combustion_ble/__init__.py
+++ b/combustion_ble/__init__.py
@@ -2,12 +2,18 @@
 
 """Top-level package for cobustion_ble."""
 
+from combustion_ble.ble_data.advertising_data import (
+    AdvertisingData,
+    CombustionProductType,
+)
+from combustion_ble.ble_data.mode_id import ProbeColor, ProbeID, ProbeMode
 from combustion_ble.ble_data.prediction_state import PredictionState
 from combustion_ble.ble_data.prediction_status import (
     PredictionMode,
     PredictionStatus,
     PredictionType,
 )
+from combustion_ble.ble_manager import BluetoothMode
 from combustion_ble.device_manager import DeviceManager
 from combustion_ble.devices.probe import VirtualTemperatures
 from combustion_ble.version import VERSION, VERSION_SHORT
@@ -15,11 +21,17 @@ from combustion_ble.version import VERSION, VERSION_SHORT
 __all__ = [
     "VERSION",
     "VERSION_SHORT",
+    "AdvertisingData",
+    "BluetoothMode",
+    "CombustionProductType",
     "DeviceManager",
     "devices",
     "PredictionMode",
     "PredictionStatus",
     "PredictionType",
     "PredictionState",
+    "ProbeID",
+    "ProbeColor",
+    "ProbeMode",
     "VirtualTemperatures",
 ]

--- a/combustion_ble/device_manager.py
+++ b/combustion_ble/device_manager.py
@@ -2,13 +2,15 @@
 import asyncio
 from typing import Callable, Optional
 
+from bleak import AdvertisementDataCallback
+
 from combustion_ble.ble_data.advertising_data import (
     AdvertisingData,
     CombustionProductType,
 )
 from combustion_ble.ble_data.hop_count import HopCount
 from combustion_ble.ble_data.probe_status import ProbeStatus
-from combustion_ble.ble_manager import BleManager, BleManagerDelegate
+from combustion_ble.ble_manager import BleManager, BleManagerDelegate, BluetoothMode
 from combustion_ble.connection_manager import ConnectionManager
 from combustion_ble.devices.device import Device
 from combustion_ble.devices.meat_net_node import MeatNetNode
@@ -98,9 +100,11 @@ class DeviceManager(BleManagerDelegate):
         BleManager.shared.delegate = self
         self.timer_task: asyncio.Task | None = asyncio.create_task(self._start_timers())
 
-    async def init_bluetooth(self):
+    async def init_bluetooth(
+        self, mode: BluetoothMode = BluetoothMode.ACTIVE
+    ) -> Optional[AdvertisementDataCallback]:
         """Initialize bluetooth operations."""
-        await BleManager.shared.init_bluetooth()
+        return await BleManager.shared.init_bluetooth(mode=mode)
 
     def add_device_listener(self, listener: DeviceListener) -> None:
         """Add a device listener to be notified when devices are added or removed."""

--- a/examples/passive_scanner.py
+++ b/examples/passive_scanner.py
@@ -1,0 +1,72 @@
+"""This example illustrates how you can use an external BleakScanner via the passive mode."""
+import asyncio
+from signal import SIGINT, SIGTERM
+
+from bleak import BleakScanner
+from rich.live import Live
+from rich.table import Table
+
+from combustion_ble.ble_manager import BluetoothMode
+from combustion_ble.device_manager import DeviceManager
+from combustion_ble.devices.probe import Probe
+from examples._example_utils import (
+    configure_logging,
+    format_connection_state,
+    format_device_name,
+    format_temperatures,
+)
+
+
+async def main():
+    dm = DeviceManager()
+    dm.enable_meatnet()
+    detection_callback = await dm.init_bluetooth(mode=BluetoothMode.PASSIVE)
+
+    scanner = BleakScanner(detection_callback=detection_callback)
+    await scanner.start()
+
+    def generate_table():
+        table = Table()
+        table.add_column("Device")
+        table.add_column("Versions")
+        table.add_column("State")
+        table.add_column("Last update time")
+        table.add_column("Details")
+
+        devices = dm.get_devices()
+        for device in devices:
+            name = format_device_name(device)
+            connection = format_connection_state(device.connection_state)
+            versions = f"fw: {device.firmware_version} hw: {device.hardware_revision}"
+            if isinstance(device, Probe):
+                temperatures = format_temperatures(device._current_temperatures)
+                table.add_row(
+                    name, versions, connection, str(device.last_update_time), temperatures
+                )
+            else:
+                details = f"RSSI: {device.rssi}"
+                table.add_row(name, versions, connection, str(device.last_update_time), details)
+
+        return table
+
+    try:
+        with Live(generate_table(), refresh_per_second=4) as live:
+            live.console.print(":detective:  Scanning for devices", emoji=True)
+            while True:
+                await asyncio.sleep(0.25)
+                live.update(generate_table())
+    except asyncio.CancelledError:
+        await scanner.stop()
+        await dm.async_stop()
+
+
+if __name__ == "__main__":
+    configure_logging()
+    loop = asyncio.get_event_loop()
+    main_task = asyncio.ensure_future(main())
+    for signal in [SIGINT, SIGTERM]:
+        loop.add_signal_handler(signal, main_task.cancel)
+    try:
+        loop.run_until_complete(main_task)
+    finally:
+        loop.close()


### PR DESCRIPTION
Allows for external scanners to be used via new `BluetoothMode` setting during bluetooth initialization.